### PR TITLE
fix function name typo

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -51,7 +51,7 @@
 
 	<?php
 		// If comments are closed and there are comments, let's leave a little note, shall we?
-		if ( ! comments_open() && '0' != get_comments_number() && post_type_jointsthemeupports( get_post_type(), 'comments' ) ) :
+		if ( ! comments_open() && '0' != get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
 	?>
 		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', '_jointstheme' ); ?></p>
 	<?php endif; ?>


### PR DESCRIPTION
The function `post_type_jointsthemeupports` doesn't exit and should be renamed `post_type_supports`. This code is called on post with comments closed with count > 0.
